### PR TITLE
Enable saving the raw blocks to the database

### DIFF
--- a/etc/config.ini.php.dist
+++ b/etc/config.ini.php.dist
@@ -6,7 +6,8 @@ rpcurls[]='https://api.steemit.com/'
 ;rpcurls[]='https://api.steem.house/'
 
 [block]
-start=22000000
+start=0
+saverawblock=0
 
 [requests]
 concurrent_requests=10

--- a/src/PCSG/SteemBlockchainParser/Block.php
+++ b/src/PCSG/SteemBlockchainParser/Block.php
@@ -41,14 +41,14 @@ use PCSG\SteemBlockchainParser\Types\WitnessUpdate;
 class Block
 {
     protected $blockNumber;
-
+    protected $raw;
     protected $blockID;
     protected $transactions;
     protected $dateTime;
     protected $previous;
     protected $witness;
     protected $witness_signature;
-    protected $transaktion_merkle_root;
+    protected $transaction_merkle_root;
 
     /**
      * Block constructor.
@@ -209,13 +209,13 @@ class Block
     protected function insertBlockIntoDatabase()
     {
         Parser::getDatabase()->insert("sbds_core_blocks", [
-            "raw"                     => "",
+            "raw"                     => $this->raw,
             "block_num"               => $this->blockNumber,
             "previous"                => $this->previous,
             "timestamp"               => $this->dateTime,
             "witness"                 => $this->witness,
             "witness_signature"       => $this->witness_signature,
-            "transaction_merkle_root" => $this->transaktion_merkle_root
+            "transaction_merkle_root" => $this->transaction_merkle_root
         ]);
     }
 
@@ -374,31 +374,44 @@ class Block
     {
         $RPCClient = new RPCClient();
         $blockData = $RPCClient->execute("get_block", [$this->blockNumber]);
-
+        $saverawblock = Config::getInstance()->get("block", "saverawblock");
+        if (isset($saverawblock) && (int)$saverawblock === 1) {
+          $this->raw                     = json_encode($blockData);
+        }
+        else {
+          $this->raw                     = "";
+        }
         $this->blockID                 = $blockData['block_id'];
         $this->dateTime                = $blockData['timestamp'];
         $this->transactions            = $blockData['transactions'];
         $this->previous                = $blockData['previous'];
         $this->witness                 = $blockData['witness'];
         $this->witness_signature       = $blockData['witness_signature'];
-        $this->transaktion_merkle_root = $blockData['transaction_merkle_root'];
+        $this->transaction_merkle_root = $blockData['transaction_merkle_root'];
     }
 
     /**
      * Loads the data from the given array into the object.
-     * This can be used for mass imports, when you want to run paralell guzzle requests to enter a lot of blocks simultanously
+     * This can be used for mass imports, when you want to run parallel guzzle requests to enter a lot of blocks simultaneously
      *
      * @param array $blockData
      */
     protected function loadDataFromArray(array $blockData)
     {
+        $saverawblock = Config::getInstance()->get("block", "saverawblock");
+        if (isset($saverawblock) && (int)$saverawblock === 1) {
+          $this->raw                     = json_encode($blockData);
+        }
+        else {
+          $this->raw                     = "";
+        }
         $this->blockID                 = $blockData['block_id'];
         $this->dateTime                = $blockData['timestamp'];
         $this->transactions            = $blockData['transactions'];
         $this->previous                = $blockData['previous'];
         $this->witness                 = $blockData['witness'];
         $this->witness_signature       = $blockData['witness_signature'];
-        $this->transaktion_merkle_root = $blockData['transaction_merkle_root'];
+        $this->transaction_merkle_root = $blockData['transaction_merkle_root'];
     }
 
     /**


### PR DESCRIPTION
- Enable saving the raw blocks to the database, configurable in the `config.ini.php`. It's off by default, to avoid an excessively large table.
- Minor spelling corrections.

Notes about the config.ini.php
- Should use `start=0` to start getting data from block number 1 inclusively.
- `saverawblock=0` disables saving raw block to database, set to 1 to enable.
